### PR TITLE
Add toggle for building testing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,21 +25,23 @@ cmaize_add_library(
     DEPENDS CMakePublic::CMakePublic
 )
 
-# Build tests
-cpp_find_or_build_dependency(
-    Catch2
-    URL github.com/catchorg/Catch2
-    BUILD_TARGET Catch2
-    FIND_TARGET Catch2::Catch2WithMain
-    VERSION v3.0.1
-)
+if (BUILD_TESTING)
+    # Build tests
+    cpp_find_or_build_dependency(
+        Catch2
+        URL github.com/catchorg/Catch2
+        BUILD_TARGET Catch2
+        FIND_TARGET Catch2::Catch2WithMain
+        VERSION v3.0.1
+    )
 
-cmaize_add_tests(
-    test_${PROJECT_NAME}
-    SOURCE_DIR "${CMAKE_CURRENT_LIST_DIR}/test/cmaize_public_depend"
-    INCLUDE_DIRS "${CMAKE_CURRENT_LIST_DIR}/src/cmaize_public_depend"
-    DEPENDS Catch2::Catch2WithMain ${PROJECT_NAME}
-)
+    cmaize_add_tests(
+        test_${PROJECT_NAME}
+        SOURCE_DIR "${CMAKE_CURRENT_LIST_DIR}/test/cmaize_public_depend"
+        INCLUDE_DIRS "${CMAKE_CURRENT_LIST_DIR}/src/cmaize_public_depend"
+        DEPENDS Catch2::Catch2WithMain ${PROJECT_NAME}
+    )
+endif()
 
 # Install the package
 cmaize_add_package(${PROJECT_NAME})


### PR DESCRIPTION
This adds an if statement around the code that adds unit tests to be built. This allows them to be toggled off by projects depending on this project.